### PR TITLE
Fix pins save when file missing

### DIFF
--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -48,14 +48,18 @@ class GitHubService {
     const content = btoa(JSON.stringify(updatedPins, null, 2));
     
     try {
+      const sha = await this.getFileSha(PINS_FILE_PATH);
+      const body: any = {
+        message: `Add pin for ${pin.name}`,
+        content,
+      };
+      if (sha) {
+        body.sha = sha;
+      }
       const response = await fetch(`${this.baseUrl}/contents/${PINS_FILE_PATH}`, {
         method: 'PUT',
         headers: this.headers,
-        body: JSON.stringify({
-          message: `Add pin for ${pin.name}`,
-          content,
-          sha: await this.getFileSha(PINS_FILE_PATH),
-        }),
+        body: JSON.stringify(body),
       });
 
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- avoid sending empty SHA when pins file doesn't exist

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685ee78416608323a1f15729436405e4